### PR TITLE
Initialize $joinColumnsArray on each join

### DIFF
--- a/app/Models/PersistenceModel.php
+++ b/app/Models/PersistenceModel.php
@@ -112,6 +112,7 @@ class PersistenceModel
                     $joinColumnsQuery = '';
                     $joinTableQuery = '';
                     $joinOrderQuery = '';
+                    $joinColumnsArray = [] ;
 
                     foreach ($join['columns'] as $joinColumnName => $joinColumn) {
                         $joinColumnQueryName = $this->db->backtick($joinColumnName);


### PR DESCRIPTION
Having this uninitialized was causing join columns to pile up in $joinColumnsArray If you have columns joined from different tables with different names, and the second joined table doesn't have a column configured to be joined from the first join, an exception is thrown 'No such column'.