### PR TITLE
Subroot quick - Allow the app to be installed below the document root

### DIFF
--- a/app/Config/App.php
+++ b/app/Config/App.php
@@ -2,4 +2,5 @@
 
 return [
     'frontController' => 'App\Controllers\FrontController', //front controller class; string
+    'base_uri_path' => str_replace( '/'. basename( $_SERVER['SCRIPT_NAME'] ), '', $_SERVER['SCRIPT_NAME'] ),
 ];

--- a/app/Misc/Router.php
+++ b/app/Misc/Router.php
@@ -13,8 +13,8 @@ class Router
     public function __construct()
     {
         $dispatcher = FastRoute\simpleDispatcher(function(FastRoute\RouteCollector $collector) {
-            $collector->addRoute(['GET'], '/logout', [new \App\Controllers\FrontController(), 'logout']);
-            $collector->addRoute(['GET', 'POST'], '/[{table}[/{action}[/{id}]]]', [new \App\Controllers\FrontController(), 'main']);
+            $collector->addRoute(['GET'], BASE_PATH .'/logout', [new \App\Controllers\FrontController(), 'logout']);
+            $collector->addRoute(['GET', 'POST'], BASE_PATH .'/[{table}[/{action}[/{id}]]]', [new \App\Controllers\FrontController(), 'main']);
         });
 
         $factory = new Abimo\Factory();

--- a/app/Misc/Router.php
+++ b/app/Misc/Router.php
@@ -17,9 +17,11 @@ class Router
 
         $frontController = $factory->config()->get('app', 'frontController');
         $frontController = new $frontController;
+        
+        $base_uri_path = $factory->config()->get('app','base_uri_path');
 
-        $dispatcher = FastRoute\simpleDispatcher(function(FastRoute\RouteCollector $collector) use ($frontController) {
-            $collector->addRoute(['GET', 'POST'], '/[{table}[/{action}[/{id}]]]', [new $frontController, 'main']);
+        $dispatcher = FastRoute\simpleDispatcher(function(FastRoute\RouteCollector $collector) use ($frontController, $base_uri_path) {
+            $collector->addRoute(['GET', 'POST'], $base_uri_path .'/[{table}[/{action}[/{id}]]]', [new $frontController, 'main']);
         });
 
         $request = $factory->request();

--- a/app/Models/BusinessModel.php
+++ b/app/Models/BusinessModel.php
@@ -220,7 +220,7 @@ class BusinessModel
         }
 
         $publicPath = rtrim($this->config->get('admin', 'publicPath'), '/');
-        $imageDomain = trim($this->config->get('admin', 'imageDomain'), '/');
+        $imageDomain = trim($this->config->get('admin', 'imageDomain') . BASE_PATH, '/');
         $imageDir = trim($this->config->get('admin', 'imageDir'), '/');
 
         if (!empty($_FILES)) {

--- a/app/Models/BusinessModel.php
+++ b/app/Models/BusinessModel.php
@@ -216,9 +216,10 @@ class BusinessModel
             return;
         }
 
-
+        $base_uri_path = $this->factory->config()->get('app','base_uri_path');
+        
         $imagePublicPath = rtrim($this->config->get('admin', 'imagePublicPath'), '/');
-        $imageDomain = trim($this->config->get('admin', 'imageDomain'), '/');
+        $imageDomain = trim($this->config->get('admin', 'imageDomain') . $base_uri_path, '/');
         $imageDir = trim($this->config->get('admin', 'imageDir'), '/');
 
         if (!empty($_FILES)) {

--- a/app/Models/UrlModel.php
+++ b/app/Models/UrlModel.php
@@ -26,7 +26,10 @@ class UrlModel
             }
         }
 
-        return $this->prepare( BASE_PATH .'/'.implode('/', $pattern), [
+        $factory = new \Abimo\Factory();
+        $base_uri_path = $factory->config()->get('app','base_uri_path');
+        
+        return $this->prepare( $base_uri_path .'/'.implode('/', $pattern), [
             $table,
             $action,
             $id

--- a/app/Models/UrlModel.php
+++ b/app/Models/UrlModel.php
@@ -26,7 +26,7 @@ class UrlModel
             }
         }
 
-        return $this->prepare('/'.implode('/', $pattern), [
+        return $this->prepare( BASE_PATH .'/'.implode('/', $pattern), [
             $table,
             $action,
             $id

--- a/app/Views/Admin/Plugins/Image.php
+++ b/app/Views/Admin/Plugins/Image.php
@@ -6,7 +6,7 @@
         <div id="preview-<?php echo $column;?>" class="image size-large"
              style="
                 <?php echo (!empty($data[$table]['rows'][$id][$column])
-                    ? "background-image:url('". $data[$table]['rows'][$id][$column]."')"
+                    ? "background-image:url('".$data[$table]['rows'][$id][$column]."')"
                     : "background-image:url('/img/system/image-empty.png')"); ?>;"
                 >
         </div>

--- a/app/Views/Admin/Plugins/Image.php
+++ b/app/Views/Admin/Plugins/Image.php
@@ -6,7 +6,7 @@
         <div id="preview-<?php echo $column;?>" class="image size-large"
              style="
                 <?php echo (!empty($data[$table]['rows'][$id][$column])
-                    ? "background-image:url('".$data[$table]['rows'][$id][$column]."')"
+                    ? "background-image:url('". BASE_PATH . $data[$table]['rows'][$id][$column]."')"
                     : "background-image:url('/img/system/image-empty.png')"); ?>;"
                 >
         </div>

--- a/app/Views/Admin/Plugins/Image.php
+++ b/app/Views/Admin/Plugins/Image.php
@@ -6,7 +6,7 @@
         <div id="preview-<?php echo $column;?>" class="image size-large"
              style="
                 <?php echo (!empty($data[$table]['rows'][$id][$column])
-                    ? "background-image:url('". BASE_PATH . $data[$table]['rows'][$id][$column]."')"
+                    ? "background-image:url('". $data[$table]['rows'][$id][$column]."')"
                     : "background-image:url('/img/system/image-empty.png')"); ?>;"
                 >
         </div>

--- a/app/Views/Admin/Template.php
+++ b/app/Views/Admin/Template.php
@@ -10,8 +10,8 @@
         <meta content="" property="og:image">
         <meta content="A simple database administration tool for simple CRUD operations." property="og:description">
         <meta content="https://github.com/sitilge/curdle" property="og:url">
-        <link rel="stylesheet" href="/css/all.css">
-        <script src="/js/all.js"></script>
+        <link rel="stylesheet" href="<?=$url->admin()?>css/all.css">
+        <script src="<?=$url->admin()?>js/all.js"></script>
     </head>
     <body>
         <nav class="navbar navbar-default navbar-fixed-top">

--- a/app/Views/Admin/Template.php
+++ b/app/Views/Admin/Template.php
@@ -10,8 +10,8 @@
         <meta content="" property="og:image">
         <meta content="A simple database administration tool for simple CRUD operations." property="og:description">
         <meta content="https://github.com/sitilge/curdle" property="og:url">
-        <link rel="stylesheet" href="<?=$url->admin()?>css/all.css">
-        <script src="<?=$url->admin()?>js/all.js"></script>
+        <link rel="stylesheet" href="<?php echo $url->admin()?>css/all.css">
+        <script src="<?php echo $url->admin()?>js/all.js"></script>
     </head>
     <body>
         <nav class="navbar navbar-default navbar-fixed-top">

--- a/public/index.php
+++ b/public/index.php
@@ -15,5 +15,8 @@ $factory
     ->configure()
     ->register();
 
+define('BASE_PATH', str_replace( '/'. basename( __FILE__ ), '', $_SERVER['SCRIPT_NAME'] ) );
+
+
 //initialize router and dispatch
 new \App\Misc\Router();

--- a/public/index.php
+++ b/public/index.php
@@ -15,8 +15,6 @@ $factory
     ->configure()
     ->register();
 
-define('BASE_PATH', str_replace( '/'. basename( __FILE__ ), '', $_SERVER['SCRIPT_NAME'] ) );
-
 
 //initialize router and dispatch
 new \App\Misc\Router();


### PR DESCRIPTION
Here's the quick and dirty version - because it was quicker, of course!

In index.php, we define a global BASE_PATH constant, which is used in the Router route declarations, and in UrlModel to produce uri paths that are always correctly relative to the document root, and in the BusinessModel to make sure file uploads still work. 
