### PR TITLE
A little dependency injection and tweaks to help subclassing

### DIFF
--- a/app/Config/App.php
+++ b/app/Config/App.php
@@ -1,5 +1,6 @@
 <?php
 
 return [
-    'development' => false //app development mode; array(true, false)
+    'development' => false, //app development mode; array(true, false)
+    'front_controller_class' => App\Controllers\FrontController::class,
 ];

--- a/app/Controllers/FrontController.php
+++ b/app/Controllers/FrontController.php
@@ -11,32 +11,32 @@ class FrontController
     /**
      * @var string
      */
-    private $table;
+    protected $table;
 
     /**
      * @var string
      */
-    private $action;
+    protected $action;
 
     /**
      * @var string
      */
-    private $id;
+    protected $id;
 
     /**
      * @var Factory
      */
-    private $factory;
+    protected $factory;
 
     /**
      * @var BusinessModel
      */
-    private $businessModel;
+    protected $businessModel;
 
     /**
      * @var UrlModel
      */
-    private $urlModel;
+    protected $urlModel;
 
     /**
      * FrontController constructor.
@@ -46,6 +46,7 @@ class FrontController
         $this->factory = new Factory();
         $this->urlModel = new UrlModel();
         $this->businessModel = new BusinessModel() ;
+        
     }
 
     /**

--- a/app/Controllers/FrontController.php
+++ b/app/Controllers/FrontController.php
@@ -45,6 +45,7 @@ class FrontController
     {
         $this->factory = new Factory();
         $this->urlModel = new UrlModel();
+        $this->businessModel = new BusinessModel() ;
     }
 
     /**
@@ -59,8 +60,9 @@ class FrontController
         $this->table = $table;
         $this->action = $action;
         $this->id = $id;
-
-        $this->businessModel = new BusinessModel($this->table, $this->action, $this->id);
+        
+        $businessModel = $this->businessModel ;
+        $this->businessModel = new $businessModel($this->table, $this->action, $this->id);
 
         $content = $this->getContent();
         $menu = $this->getMenu();

--- a/app/Misc/Router.php
+++ b/app/Misc/Router.php
@@ -12,12 +12,28 @@ class Router
      */
     public function __construct()
     {
-        $dispatcher = FastRoute\simpleDispatcher(function(FastRoute\RouteCollector $collector) {
-            $collector->addRoute(['GET'], '/logout', [new \App\Controllers\FrontController(), 'logout']);
-            $collector->addRoute(['GET', 'POST'], '/[{table}[/{action}[/{id}]]]', [new \App\Controllers\FrontController(), 'main']);
-        });
-
         $factory = new Abimo\Factory();
+        
+        $front_controller_class = $factory->config()->get('app','front_controller_class') ;
+        
+        $dispatcher = FastRoute\simpleDispatcher(
+          function(FastRoute\RouteCollector $collector) use ( $front_controller_class ) {
+            
+              $collector->addRoute(['GET'], '/logout', 
+                  function() use ($front_controller_class) { 
+                      return ( new $front_controller_class )->logout() ; 
+                  } 
+              );
+              
+              $collector->addRoute(['GET', 'POST'], '/[{table}[/{action}[/{id}]]]',
+                  function($table = null, $action = null, $id = null) use ($front_controller_class) { 
+                      return ( new $front_controller_class )->main($table,$action,$id) ; 
+                  } 
+              );
+              
+          });
+
+        
         $request = $factory->request();
 
         $method = $request->method();

--- a/app/Models/PersistenceModel.php
+++ b/app/Models/PersistenceModel.php
@@ -112,6 +112,7 @@ class PersistenceModel
                     $joinColumnsQuery = '';
                     $joinTableQuery = '';
                     $joinOrderQuery = '';
+                    $joinColumnsArray = [] ;
 
                     foreach ($join['columns'] as $joinColumnName => $joinColumn) {
                         $joinColumnQueryName = $this->db->backtick($joinColumnName);


### PR DESCRIPTION
I'd like to be able to extend some of these classes in my own installations of Curdle, so I'm wondering if you would accept these to make it a little more flexible:

* In the Router class, you were instantiating two separate FrontControllers for every request, even if neither of them were used. I've cleaned this up by declaring the route callables as closures instead. 

in addition, I've added a config option to App.php 'front_controller_class', that will allow alternate FrontController classes to be instantiated (which I'll be doing soon). 

* Also, In order to make swapping out BusinessModels easier, I've moved its instantiation in FrontController::main() into the constructor, which is much easier to override in subclasses. main() now jsut instantiates a new businessmodel of the same class with the route parameters, when it gets them. I've also loosened up the visibility to make it easier for FrontController subclasses to swap out its dependencies in the constructor.

This will make keeping up with your upstream a heck of a lot easier for me. Thoughts?

(Please excuse the unnecessary merges near the end; i'm still getting the hang of how Github does things)