### PR TITLE
promoting visibility of FrontController->getMenu()

### DIFF
--- a/app/Controllers/FrontController.php
+++ b/app/Controllers/FrontController.php
@@ -112,7 +112,7 @@ class FrontController
      *
      * @return array
      */
-    private function getMenu()
+    protected function getMenu()
     {
         return $this->businessModel->data;
     }


### PR DESCRIPTION
I'm working with a subclass of FrontController, and getMenu() is an ideal place to customize which tables are allowed to appear on the sidebar menu. changing visibility from private to protected allows my class to override getMenu() much more easily. 

Pretty please?